### PR TITLE
`dns4` to resolve onion address instead of `onion3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,12 @@
     "libp2p-mplex": "^0.10.3",
     "libp2p-noise": "^3.0.0",
     "libp2p-tcp": "^0.15.4",
-    "libp2p-websockets": "git+https://github.com/da-kami/js-libp2p-websockets.git#84f5b1a48c25a546c6b4b617990a6e15f74db9fa",
+    "libp2p-websockets": "^0.15.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
-  },
-  "resolutions": {
-    "**/multiaddr-to-uri": "git+https://github.com/da-kami/js-multiaddr-to-uri.git#b3ee17539b303341c4f827514ba29664d5d16a7d"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/useAsb.tsx
+++ b/src/useAsb.tsx
@@ -11,7 +11,7 @@ import wrap from "it-pb-rpc";
 const QUOTE_PROTOCOL = '/comit/xmr/btc/bid-quote/1.0.0';
 
 // Note: The multiaddr needs the ws protocl specifier to be processed correctly
-const ASB_MULTI_ADR_TESTNET = '/onion3/pzbmpqsyi2j2za2fwmiognupwozjlcoajbd3cgboetql7ooah63zywqd:9940/ws';
+const ASB_MULTI_ADR_TESTNET = '/dns4/pzbmpqsyi2j2za2fwmiognupwozjlcoajbd3cgboetql7ooah63zywqd.onion/tcp/9940/ws';
 const ASB_PEER_ID_TESTNET =
     '12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi';
 

--- a/src/useAsb.tsx
+++ b/src/useAsb.tsx
@@ -11,9 +11,9 @@ import wrap from "it-pb-rpc";
 const QUOTE_PROTOCOL = '/comit/xmr/btc/bid-quote/1.0.0';
 
 // Note: The multiaddr needs the ws protocl specifier to be processed correctly
-const ASB_MULTI_ADR_TESTNET = '/dns4/pzbmpqsyi2j2za2fwmiognupwozjlcoajbd3cgboetql7ooah63zywqd.onion/tcp/9940/ws';
+const ASB_MULTI_ADR_TESTNET = '/ip4/192.168.1.8/tcp/8740/ws';
 const ASB_PEER_ID_TESTNET =
-    '12D3KooWCdMKjesXMJz1SiZ7HgotrxuqhQJbP5sgBm2BwP1cqThi';
+    '12D3KooWPZ69DRp4wbGB3wJsxxsg1XW1EVZ2evtVwcARCF3a1nrx';
 
 export function getPeerId(): PeerId {
       return PeerId.createFromB58String(ASB_PEER_ID_TESTNET);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7662,9 +7662,10 @@ libp2p-utils@^0.3.0, libp2p-utils@^0.3.1:
     multiaddr "^9.0.1"
     private-ip "^2.1.1"
 
-"libp2p-websockets@git+https://github.com/da-kami/js-libp2p-websockets.git#84f5b1a48c25a546c6b4b617990a6e15f74db9fa":
+libp2p-websockets@^0.15.7:
   version "0.15.8"
-  resolved "git+https://github.com/da-kami/js-libp2p-websockets.git#84f5b1a48c25a546c6b4b617990a6e15f74db9fa"
+  resolved "https://registry.yarnpkg.com/libp2p-websockets/-/libp2p-websockets-0.15.8.tgz#809a801b42939ed386194f17163a4f9f0ca99d51"
+  integrity sha512-n8WMk/EEVgf7/k1sVm2FtMn+Atji9KPFwy194azxJ0j5G3WOcQVvCqe/OiMX6jDmxdbQEi/bczDxGxI2l6vzAw==
   dependencies:
     abortable-iterator "^3.0.0"
     class-is "^1.1.0"
@@ -8237,7 +8238,7 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multiaddr-to-uri@^7.0.0, "multiaddr-to-uri@git+https://github.com/da-kami/js-multiaddr-to-uri.git#b3ee17539b303341c4f827514ba29664d5d16a7d":
+multiaddr-to-uri@^7.0.0:
   version "7.0.0"
   resolved "git+https://github.com/da-kami/js-multiaddr-to-uri.git#b3ee17539b303341c4f827514ba29664d5d16a7d"
   dependencies:


### PR DESCRIPTION
Apparently, we don't need to use the `onion3` spec of multiaddress to achieve a connection to a websocket.
Onion addresses can be used with `dns4`, e.g.: `/dns4/pzbmpqsyi2j2za2fwmiognupwozjlcoajbd3cgboetql7ooah63zywqd.onion/tcp/9940/ws`, and the connection will work out fine.
There is no need to adapt libraries to support `onion3` spec for this :)

Note, as pointed out [here](https://github.com/libp2p/js-libp2p-websockets/pull/131) this is possible because Tor and Brave browser support onion addresses as TLD.